### PR TITLE
added testbed to env varialges and api path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Dockerfile for building container. [#19](https://github.com/IN-CORE/maestro-service/issues/19)
 - GitHub action for automation of container building. [#23](https://github.com/IN-CORE/maestro-service/issues/23)
+
+### Change
+- API takes the testbed name in its routes. [#31](https://github.com/IN-CORE/maestro-service/issues/31)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ENV POSTGRES_SERVER=localhost \
     POSTGRES_USER=maestro \
     POSTGRES_PASSWORD=maestro \
     POSTGRES_DB=maestro \
-    ROUTER_PREFIX="/maestro"
+    ROUTER_PREFIX="/maestro" \
+    TESTBED=slc
 
 CMD gunicorn -b 0.0.0.0:8000 -w ${WORKERS} -k uvicorn.workers.UvicornWorker app.main:app
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str
     POSTGRES_PORT: str
+    TESTBED: str
 
     SQLALCHEMY_DATABASE_URI: Optional[PostgresDsn] = None
 
@@ -37,6 +38,7 @@ class Settings(BaseSettings):
             port=values.get("POSTGRES_PORT"),
             db_name=values.get("POSTGRES_DB"),
             path=f"/{db_name}",
+            testbed=values.get("TESTBED")
         )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ api_router.include_router(
     tags=["steps"],
 )
 
+testbed = settings.TESTBED
 app.include_router(api_router, prefix=settings.ROUTER_PREFIX)
 
 
@@ -49,13 +50,14 @@ def index():
 
 
 # liveness test
-@app.get("/maestro/alive")
+@app.get("/maestro/{testbed}/alive")
 def index():
+    print(testbed)
     return {"message": "Welcome to Maestro service"}
 
 # database connection test
-@app.get("/maestro/db_test")
+@app.get("/maestro/{testbed}/db_test")
 def db_test():
     engine = create_engine(settings.SQLALCHEMY_DATABASE_URI)
-    print(engine)
+    print(testbed)
     return {"message": "The database connected successfully"}


### PR DESCRIPTION
Test this with port forwarding the dev cluster's postgresql by
kubectl port-forward -n incore services/incore-postgresql 54321:5432
and create .env to test (need to provide correct password. Ask me if you don't know)

Or if you have postgresql installed in our local , set sever, port, and db accordingly and test

```
POSTGRES_SERVER=localhost
POSTGRES_PORT=54321
POSTGRES_USER=maestro
POSTGRES_PASSWORD=password
POSTGRES_DB=maestro
ROUTER_PREFIX=/maestro
TESTBED=slc
```

then check the endpoints
http://127.0.0.1:8000/maestro/slc/alive
http://127.0.0.1:8000/maestro/slc/db_test
