### PR TITLE
45 save retrofit strategy query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+### Added 
+-  Endpoint to read, write and delete retrofit strategy related to a dataset [#45](https://github.com/IN-CORE/maestro-service/issues/45)
+
+
 ## [1.0.0] - 2023-03-15
 
 ### Added

--- a/app/crud/DatasetCRUD.py
+++ b/app/crud/DatasetCRUD.py
@@ -1,28 +1,27 @@
 from typing import Optional
 
-from bson import ObjectId
 from fastapi import HTTPException
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
-from app.db.schemas import RetrofitStrategy
+from app.db.schemas import RetrofitStrategy, RetrofitStrategyBase
 from app.models.RetrofitStrategyDetails import RetrofitStrategyDetails as RetrofitStrategyDetailsModel
 from app.crud.base import CRUDBase
 
 
-class DatasetCRUD(CRUDBase[RetrofitStrategyDetailsModel, RetrofitStrategy]):
+class DatasetCRUD(CRUDBase[RetrofitStrategyDetailsModel, RetrofitStrategyBase, RetrofitStrategy]):
     def get_rsdetails(self, db: Session, dataset_id: str) -> Optional[RetrofitStrategy]:
 
         return (
             db.query(RetrofitStrategyDetailsModel)
-            .filter(and_(RetrofitStrategyDetailsModel.dataset_id == ObjectId(dataset_id)))
+            .filter(and_(RetrofitStrategyDetailsModel.dataset_id == dataset_id))
             .first()
         )
 
     def delete_rsdetails(self, db: Session, dataset_id: str) -> Optional[RetrofitStrategy]:
         if (
             db_rsdetails := db.query(RetrofitStrategyDetailsModel)
-            .filter(and_(RetrofitStrategyDetailsModel.dataset_id == ObjectId(dataset_id)))
+            .filter(and_(RetrofitStrategyDetailsModel.dataset_id == dataset_id))
             .first()
         ) is not None:
             try:

--- a/app/crud/DatasetCRUD.py
+++ b/app/crud/DatasetCRUD.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from bson import ObjectId
+from fastapi import HTTPException
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
+from app.db.schemas import RetrofitStrategy
+from app.models.RetrofitStrategyDetails import RetrofitStrategyDetails as RetrofitStrategyDetailsModel
+from app.crud.base import CRUDBase
+
+
+class DatasetCRUD(CRUDBase[RetrofitStrategyDetailsModel, RetrofitStrategy]):
+    def get_rsdetails(self, db: Session, dataset_id: str) -> Optional[RetrofitStrategy]:
+
+        return (
+            db.query(RetrofitStrategyDetailsModel)
+            .filter(and_(RetrofitStrategyDetailsModel.dataset_id == ObjectId(dataset_id)))
+            .first()
+        )
+
+    def delete_rsdetails(self, db: Session, dataset_id: str) -> Optional[RetrofitStrategy]:
+        if (
+            db_rsdetails := db.query(RetrofitStrategyDetailsModel)
+            .filter(and_(RetrofitStrategyDetailsModel.dataset_id == ObjectId(dataset_id)))
+            .first()
+        ) is not None:
+            try:
+                db.delete(db_rsdetails)
+                db.commit()
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=e.args[0])
+            return db_rsdetails
+        raise HTTPException(status_code=404, detail=f"Retrofit strategy detail for dataset {dataset_id} not found")
+
+
+datasetCRUD = DatasetCRUD(RetrofitStrategyDetailsModel)

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,3 +1,4 @@
 from .StepCRUD import stepCRUD
 from .UserCRUD import userCRUD
 from .RoleCRUD import roleCRUD
+from .DatasetCRUD import datasetCRUD

--- a/app/db/schemas.py
+++ b/app/db/schemas.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from bson import ObjectId
 from pydantic import BaseModel
 from datetime import datetime
 
@@ -79,12 +78,11 @@ class StepUpdate(StepBase):
 
 
 class RetrofitStrategyBase(BaseModel):
-    dataset_id: ObjectId
+    dataset_id: str
     total: dict
     by_rule: dict
 
 
 class RetrofitStrategy(RetrofitStrategyBase):
-    id: int
     class Config:
         orm_mode = True

--- a/app/db/schemas.py
+++ b/app/db/schemas.py
@@ -1,4 +1,6 @@
 from typing import Optional
+
+from bson import ObjectId
 from pydantic import BaseModel
 from datetime import datetime
 
@@ -75,3 +77,14 @@ class StepUpdate(StepBase):
     status: Optional[str]
     doc_uri: Optional[str]
 
+
+class RetrofitStrategyBase(BaseModel):
+    dataset_id: ObjectId
+    total: dict
+    by_rule: dict
+
+
+class RetrofitStrategy(RetrofitStrategyBase):
+    id: int
+    class Config:
+        orm_mode = True

--- a/app/db/schemas.py
+++ b/app/db/schemas.py
@@ -81,6 +81,9 @@ class RetrofitStrategyBase(BaseModel):
     dataset_id: str
     total: dict
     by_rule: dict
+    rules: dict
+    retrofits: dict
+    rsDetailsLayerId: str
 
 
 class RetrofitStrategy(RetrofitStrategyBase):

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 
 from app.core.config import get_settings
 from app.db.database import engine, Base
-from app.routers import users, roles, steps
+from app.routers import users, roles, steps, datasets
 
 settings = get_settings()
 
@@ -38,6 +38,11 @@ api_router.include_router(
     steps.router,
     prefix="/steps",
     tags=["steps"],
+)
+api_router.include_router(
+    datasets.router,
+    prefix="/datasets",
+    tags=["datasets"],
 )
 
 testbed = settings.TESTBED

--- a/app/models/RetrofitStrategyDetails.py
+++ b/app/models/RetrofitStrategyDetails.py
@@ -1,5 +1,4 @@
-from bson import ObjectId
-from sqlalchemy import Column, JSON
+from sqlalchemy import Column, JSON, String
 
 from app.db.database import Base
 
@@ -33,7 +32,7 @@ class RetrofitStrategyDetails(Base):
        """
     __tablename__ = "rsdetails"
 
-    dataset_id: ObjectId = Column(ObjectId, primary_key=True, index=True)
+    dataset_id: str = Column(String, primary_key=True, index=True)
     total = Column(JSON)
     by_rule = Column(JSON)
 

--- a/app/models/RetrofitStrategyDetails.py
+++ b/app/models/RetrofitStrategyDetails.py
@@ -1,0 +1,39 @@
+from bson import ObjectId
+from sqlalchemy import Column, JSON
+
+from app.db.database import Base
+
+
+class RetrofitStrategyDetails(Base):
+    """
+       {
+       "total": {
+           "num_bldg": 3283,
+           "num_bldg_no_cost": 42,
+           "cost": 117260721.43
+       },
+       "by_rule": {
+           "0": {
+               "num_bldg": 3191,
+               "num_bldg_no_cost": 40,
+               "cost": 94393478.73
+           },
+           "1": {
+               "num_bldg": 90,
+               "num_bldg_no_cost": 0,
+               "cost": 22867242.7
+           },
+           "2": {
+               "num_bldg": 2,
+               "num_bldg_no_cost": 2,
+               "cost": 0
+               }
+           }
+       }
+       """
+    __tablename__ = "rsdetails"
+
+    dataset_id: ObjectId = Column(ObjectId, primary_key=True, index=True)
+    total = Column(JSON)
+    by_rule = Column(JSON)
+

--- a/app/models/RetrofitStrategyDetails.py
+++ b/app/models/RetrofitStrategyDetails.py
@@ -4,35 +4,12 @@ from app.db.database import Base
 
 
 class RetrofitStrategyDetails(Base):
-    """
-       {
-       "total": {
-           "num_bldg": 3283,
-           "num_bldg_no_cost": 42,
-           "cost": 117260721.43
-       },
-       "by_rule": {
-           "0": {
-               "num_bldg": 3191,
-               "num_bldg_no_cost": 40,
-               "cost": 94393478.73
-           },
-           "1": {
-               "num_bldg": 90,
-               "num_bldg_no_cost": 0,
-               "cost": 22867242.7
-           },
-           "2": {
-               "num_bldg": 2,
-               "num_bldg_no_cost": 2,
-               "cost": 0
-               }
-           }
-       }
-       """
     __tablename__ = "rsdetails"
 
     dataset_id: str = Column(String, primary_key=True, index=True)
     total = Column(JSON)
     by_rule = Column(JSON)
+    rules = Column(JSON)
+    retrofits = Column(JSON)
+    rsDetailsLayerId: str = Column(String)
 

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -11,7 +11,7 @@ from app.models import RetrofitStrategyDetails
 
 router = APIRouter()
 
-s
+
 @router.get("/{dataset_id}/rsdetails", response_model=schemas.RetrofitStrategy)
 def get_retrofit_strategy_details(dataset_id: str, db:Session = Depends(get_db)) -> Any:
     rs_details = crud.datasetCRUD.get_rsdetails(db, dataset_id=dataset_id)
@@ -26,10 +26,19 @@ def post_retrofit_strategy_details(
     rsdetails: dict,
     db: Session = Depends(get_db),
 ) -> Any:
-    rsdetails["dataset_id"] = dataset_id
-    rs_details = crud.datasetCRUD.create(db, obj_in=rsdetails)
-    return rs_details
+    # Check if an entry with this dataset_id already exists
+    existing_entry = crud.datasetCRUD.get_rsdetails(db, dataset_id=dataset_id)
+    if existing_entry:
+        raise HTTPException(status_code=400, detail=f"Entry with dataset_id={dataset_id} already exists.")
 
+    rsdetails["dataset_id"] = dataset_id
+    try:
+        rs_details = crud.datasetCRUD.create(db, obj_in=rsdetails)
+    except Exception as e:
+        # Log the exception or handle it as necessary
+        raise HTTPException(status_code=500, detail="An error occurred while inserting the data.")
+
+    return rs_details
 
 @router.delete("/{dataset_id}/rsdetails", response_model=schemas.RetrofitStrategy)
 def delete_retrofit_strategy_details(dataset_id: str, db: Session = Depends(get_db)) -> Any:

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -1,0 +1,36 @@
+import json
+
+from fastapi import APIRouter, Depends, HTTPException
+from typing import Any
+
+from app import crud
+from sqlalchemy.orm import Session
+from app.db.database import get_db
+from app.db import schemas
+from app.models import RetrofitStrategyDetails
+
+router = APIRouter()
+
+s
+@router.get("/{dataset_id}/rsdetails", response_model=schemas.RetrofitStrategy)
+def get_retrofit_strategy_details(dataset_id: str, db:Session = Depends(get_db)) -> Any:
+    rs_details = crud.datasetCRUD.get_rsdetails(db, dataset_id=dataset_id)
+    if rs_details is None:
+        raise HTTPException(status_code=404, detail="retrofit strategy details not found")
+    return rs_details
+
+
+@router.post("/{dataset_id}/rsdetails", response_model=schemas.RetrofitStrategy)
+def post_retrofit_strategy_details(
+    dataset_id:str,
+    rsdetails: dict,
+    db: Session = Depends(get_db),
+) -> Any:
+    rsdetails["dataset_id"] = dataset_id
+    rs_details = crud.datasetCRUD.create(db, obj_in=rsdetails)
+    return rs_details
+
+
+@router.delete("/{dataset_id}/rsdetails", response_model=schemas.RetrofitStrategy)
+def delete_retrofit_strategy_details(dataset_id: str, db: Session = Depends(get_db)) -> Any:
+    return crud.datasetCRUD.delete_rsdetails(db, dataset_id)

--- a/app/tests/test_retrofit_strategies.py
+++ b/app/tests/test_retrofit_strategies.py
@@ -1,0 +1,60 @@
+import requests
+
+API_V2_STR = "http://localhost:8000"
+dataset_id = "65ef6a9bdc75ad0c3653ebe0"
+
+
+def test_post_retrofit_strategy_details():
+    rsdetails = {
+        "total": {
+            "num_bldg": 3283,
+            "num_bldg_no_cost": 42,
+            "cost": 117260721.43
+        },
+        "by_rule": {
+            "0": {
+                "num_bldg": 3191,
+                "num_bldg_no_cost": 40,
+                "cost": 94393478.73
+            },
+            "1": {
+                "num_bldg": 90,
+                "num_bldg_no_cost": 0,
+                "cost": 22867242.7
+            },
+            "2": {
+                "num_bldg": 2,
+                "num_bldg_no_cost": 2,
+                "cost": 0
+            }
+        }
+    }
+
+    response = requests.post(f"{API_V2_STR}/maestro/datasets/{dataset_id}/rsdetails", json=rsdetails)
+    assert response.status_code == 200  # or another status code you expect
+
+    response_data = response.json()
+    assert 'dataset_id' in response_data  # check if dataset_id is in the response
+    assert response_data['dataset_id'] == dataset_id  # verify the dataset_id matches
+
+    # duplicate entry doesn't allowed
+    response = requests.post(f"{API_V2_STR}/maestro/datasets/{dataset_id}/rsdetails", json=rsdetails)
+    assert response.status_code == 400  # or another status code you expect
+
+
+def test_get_retrofit_strategy_details():
+    response = requests.get(f"{API_V2_STR}/maestro/datasets/{dataset_id}/rsdetails")
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert 'dataset_id' in response_data
+    assert response_data['dataset_id'] == dataset_id
+    assert 'total' in response_data
+    assert 'by_rule' in response_data
+    assert response_data['total']['num_bldg'] == 3283
+    assert response_data['by_rule']['1']['num_bldg'] == 90
+
+
+def test_delete_retrofit_strategy_details():
+    response = requests.delete(f"{API_V2_STR}/maestro/datasets/{dataset_id}/rsdetails")
+    assert response.status_code == 200

--- a/app/tests/test_retrofit_strategies.py
+++ b/app/tests/test_retrofit_strategies.py
@@ -27,7 +27,19 @@ def test_post_retrofit_strategy_details():
                 "num_bldg_no_cost": 2,
                 "cost": 0
             }
-        }
+        },
+        "rules": {
+            "testbed": "galveston",
+            "rules": 3,
+            "zones": ["1P", "1P", "0.2P"],
+            "strtypes": ["1", "2", "1"],
+            "pcts": [1, 1, 1]
+        },
+        "retrofits": {
+            "ret_keys": ["elevation", "elevation", "elevation"],
+            "ret_vals": [5, 10, 5]
+        },
+        "rsDetailsLayerId": "dummy_layer_id"
     }
 
     response = requests.post(f"{API_V2_STR}/maestro/datasets/{dataset_id}/rsdetails", json=rsdetails)

--- a/app/tests/test_retrofit_strategies.py
+++ b/app/tests/test_retrofit_strategies.py
@@ -63,8 +63,15 @@ def test_get_retrofit_strategy_details():
     assert response_data['dataset_id'] == dataset_id
     assert 'total' in response_data
     assert 'by_rule' in response_data
+    assert 'rules' in response_data
+    assert 'retrofits' in response_data
+    assert 'rsDetailsLayerId' in response_data
     assert response_data['total']['num_bldg'] == 3283
     assert response_data['by_rule']['1']['num_bldg'] == 90
+    assert response_data['rules']['testbed'] == "galveston"
+    assert response_data['retrofits']['ret_keys'][0] == "elevation"
+    assert response_data['retrofits']['ret_vals'][0] == 5
+    assert response_data['rsDetailsLayerId'] == "dummy_layer_id"
 
 
 def test_delete_retrofit_strategy_details():


### PR DESCRIPTION
- GET /maestro/{testbed}/datasets/{incore_dataset_id}/rsdetails
- POST /maestro/{testbed}/datasets/{incore_dataset_id}/rsdetails
payload
```
{
        "total": {
            "num_bldg": 3283,
            "num_bldg_no_cost": 42,
            "cost": 117260721.43
        },
        "by_rule": {
            "0": {
                "num_bldg": 3191,
                "num_bldg_no_cost": 40,
                "cost": 94393478.73
            },
            "1": {
                "num_bldg": 90,
                "num_bldg_no_cost": 0,
                "cost": 22867242.7
            },
            "2": {
                "num_bldg": 2,
                "num_bldg_no_cost": 2,
                "cost": 0
            }
        },
        "rules": {
            "testbed": "galveston",
            "rules": 3,
            "zones": ["1P", "1P", "0.2P"],
            "strtypes": ["1", "2", "1"],
            "pcts": [1, 1, 1]
        },
        "retrofits": {
            "ret_keys": ["elevation", "elevation", "elevation"],
            "ret_vals": [5, 10, 5]
        },
        "rsDetailsLayerId": "dummy_layer_id"
    }
```
- DELETE /maestro/{testbed}/datasets/{incore_dataset_id}/rsdetails

----

Test **locally** by running pytest `app/tests/test_retrofit_strategies.py`
Also explore the swagger api at: http://localhost:8000/docs#/datasets